### PR TITLE
Proposed patch for Issue #1 https://github.com/Kianda/heidisql-snap/i…

### DIFF
--- a/snap/local/src/dl_f2k
+++ b/snap/local/src/dl_f2k
@@ -8,7 +8,7 @@
 
 dlf2k () {
     ver=$(wget https://api.github.com/repos/HeidiSQL/HeidiSQL/releases -qO - 2>&1 | grep tag_name | cut -d'"' -f4 | sed s'/v//' | head -n1)
-    wget https://www.heidisql.com/downloads/releases/HeidiSQL_${ver}_32_Portable.zip &> /dev/null
+    wget https://www.heidisql.com/downloads/releases/HeidiSQL_${ver}_64_Portable.zip &> /dev/null
 }
 
 dli7z16x64 () {
@@ -26,7 +26,7 @@ dli7z16x64 () {
 
 mkf2k () {
     mkdir -p ./{wine-runtime,wine-platform,bin} && mkdir -p sommelier/hooks && mkdir -p usr/share/{pixmaps,applications}
-    7z x "HeidiSQL_${ver}_32_Portable.zip" -o"usr/share/heidisql-wine" &> /dev/null
+    7z x "HeidiSQL_${ver}_64_Portable.zip" -o"usr/share/heidisql-wine" &> /dev/null
     cp usr/share/heidisql-wine/heidisql.exe usr/share/heidisql-wine/heidisql-wine.exe
     find "usr" -type d -execdir chmod 755 {} +
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ confinement: strict
 grade: stable
 architectures:
   - build-on: amd64
-    run-on: [amd64, i386]
+    run-on: [amd64]
 base: core18
 compression: lzo
 
@@ -24,7 +24,7 @@ plugs:
 
 environment:
   WINEDLLOVERRIDES: "mscoree,mshtml="         # Prevent pop-ups about Wine Mono and Wine Gecko
-  WINEARCH: "win32"
+  WINEARCH: "win64"
 
 apps:
   heidisql-wine:


### PR DESCRIPTION
#1 

Proposed patch for integrating `libmysql-8.4.0.dll` which is only available in HeidiSQL_<version>_64_Portable.zip

Note: the resulting snap package will be only usable in 64 bit versions of OSes.